### PR TITLE
Check for default values when parsing xresource

### DIFF
--- a/ini.c
+++ b/ini.c
@@ -54,8 +54,7 @@ static int ini_property(struct ini *ini, char *key, char *value)
 		}
 
 		// Add null terminator before default value for comparisons.
-		char *default_value;
-		default_value = strchr(value, ' ');
+		char *default_value = strchr(value, ' ');
 		if (default_value) {
 			if (*(default_value + 1) != '\0') {
 				default_value++;

--- a/ini.c
+++ b/ini.c
@@ -53,7 +53,8 @@ static int ini_property(struct ini *ini, char *key, char *value)
 			return -EINVAL;
 		}
 
-		// Add null terminator before default value for comparisons.
+		// Add null terminator so that xcb_xrm_resource_get_string knows where to stop.
+		int buffer_size = strlen(value);
 		char *default_value = strchr(value, ' ');
 		if (default_value) {
 			if (*(default_value + 1) != '\0') {
@@ -64,12 +65,9 @@ static int ini_property(struct ini *ini, char *key, char *value)
 
 		char *resource;
 		if (xcb_xrm_resource_get_string(ini->database, value + strlen("xresource:"), NULL, &resource) == 0) {
-			if (default_value) {
-				default_value[-1] = ' ';
-			}
-			value = resource;
+			strncpy(value, resource, buffer_size);
+			free(resource);
 		} else if (strlen(default_value) > 0) {
-			default_value[-1] = ' ';
 			value = default_value;
 		} else {
 			fatal("invalid Xresource key: \"%s\"", value);

--- a/ini.c
+++ b/ini.c
@@ -30,7 +30,7 @@ struct ini {
 	ini_sec_cb_t *sec_cb;
 	ini_prop_cb_t *prop_cb;
 	void *data;
-    xcb_xrm_database_t *database;
+	xcb_xrm_database_t *database;
 };
 
 static int ini_section(struct ini *ini, char *section)
@@ -46,22 +46,37 @@ static int ini_property(struct ini *ini, char *key, char *value)
 	if (!ini->prop_cb)
 		return 0;
 
-	// If the value begins with 'xresource:` then query Xresources for the actual value.
-    if (strncmp(value, "xresource:", strlen("xresource:")) == 0) {
-        if (!ini->database) {
-            fatal("Unable to access Xresources.");
-            return -EINVAL;
-        }
+	// If the value begins with 'xresource:` then query Xresources for the actual value or load an optional default.
+	if (strncmp(value, "xresource:", strlen("xresource:")) == 0) {
+		if (!ini->database) {
+			fatal("Unable to access Xresources.");
+			return -EINVAL;
+		}
 
-        char *resource;
-        if (xcb_xrm_resource_get_string(ini->database, value + strlen("xresource:"), NULL, &resource) == 0) {
-            value = strdup(resource);
-            free(resource);
-        } else {
-            fatal("invalid Xresource key: \"%s\"", value);
-            return -EINVAL;
-        }
-    }
+		// Add null terminator before default value for comparisons.
+		char *default_value;
+		default_value = strchr(value, ' ');
+		if (default_value) {
+			if (*(default_value + 1) != '\0') {
+				default_value++;
+				default_value[-1] = '\0';
+			}
+		}
+
+		char *resource;
+		if (xcb_xrm_resource_get_string(ini->database, value + strlen("xresource:"), NULL, &resource) == 0) {
+			if (default_value) {
+				default_value[-1] = ' ';
+			}
+			value = resource;
+		} else if (strlen(default_value) > 0) {
+			default_value[-1] = ' ';
+			value = default_value;
+		} else {
+			fatal("invalid Xresource key: \"%s\"", value);
+			return -EINVAL;
+		}
+	}
 
 	return ini->prop_cb(key, value, ini->data);
 }
@@ -115,12 +130,12 @@ static int ini_parse_line(char *line, size_t num, void *data)
 }
 
 int ini_read(int fd, size_t count, ini_sec_cb_t *sec_cb, ini_prop_cb_t *prop_cb,
-	     void *data)
+		 void *data)
 {
-    int screen;
-    xcb_connection_t *conn = xcb_connect(NULL, &screen);
+	int screen;
+	xcb_connection_t *conn = xcb_connect(NULL, &screen);
 
-    xcb_xrm_database_t *xdatabase = xcb_xrm_database_from_default(conn);
+	xcb_xrm_database_t *xdatabase = xcb_xrm_database_from_default(conn);
 
 	struct ini ini = {
 		.sec_cb = sec_cb,
@@ -131,9 +146,9 @@ int ini_read(int fd, size_t count, ini_sec_cb_t *sec_cb, ini_prop_cb_t *prop_cb,
 
 	int val = line_read(fd, count, ini_parse_line, &ini);
 
-    xcb_xrm_database_free(xdatabase);
+	xcb_xrm_database_free(xdatabase);
 
-    xcb_disconnect(conn);
+	xcb_disconnect(conn);
 
 	return val;
 }

--- a/ini.c
+++ b/ini.c
@@ -65,8 +65,9 @@ static int ini_property(struct ini *ini, char *key, char *value)
 
 		char *resource;
 		if (xcb_xrm_resource_get_string(ini->database, value + strlen("xresource:"), NULL, &resource) == 0) {
-			strncpy(value, resource, buffer_size);
+			int ret = ini->prop_cb(key, resource, ini->data);
 			free(resource);
+			return ret;
 		} else if (strlen(default_value) > 0) {
 			value = default_value;
 		} else {


### PR DESCRIPTION
The motivation for this change is to allow optional overrides, similar to the way things are configured elsewhere.

For example, updating `90_time` as follows would allow someone to change the time interval:
```
# Date Time
[time]
interval=xresource:i3xrocks.time.interval 10
```

`value` is a buffer on the stack defined in `line.c`, I think that memory is used correctly.